### PR TITLE
fix: handle HLS and Dash video formats in example app

### DIFF
--- a/example/lib/pages/hls_audio_page.dart
+++ b/example/lib/pages/hls_audio_page.dart
@@ -20,6 +20,7 @@ class _HlsAudioPageState extends State<HlsAudioPage> {
     BetterPlayerDataSource dataSource = BetterPlayerDataSource(
       BetterPlayerDataSourceType.network,
       Constants.elephantDreamStreamUrl,
+      videoFormat: BetterPlayerVideoFormat.hls,
     );
     _betterPlayerController = BetterPlayerController(betterPlayerConfiguration);
     _betterPlayerController.setupDataSource(dataSource);

--- a/example/lib/pages/hls_subtitles_page.dart
+++ b/example/lib/pages/hls_subtitles_page.dart
@@ -50,7 +50,7 @@ class _HlsSubtitlesPageState extends State<HlsSubtitlesPage> {
             ));
     BetterPlayerDataSource dataSource = BetterPlayerDataSource(
         BetterPlayerDataSourceType.network, Constants.hlsPlaylistUrl,
-        useAsmsSubtitles: true);
+        useAsmsSubtitles: true, videoFormat: BetterPlayerVideoFormat.hls);
     _betterPlayerController = BetterPlayerController(betterPlayerConfiguration);
     _betterPlayerController.setupDataSource(dataSource);
     super.initState();

--- a/example/lib/pages/hls_tracks_page.dart
+++ b/example/lib/pages/hls_tracks_page.dart
@@ -21,6 +21,7 @@ class _HlsTracksPageState extends State<HlsTracksPage> {
       BetterPlayerDataSourceType.network,
       Constants.hlsTestStreamUrl,
       useAsmsSubtitles: true,
+      videoFormat: BetterPlayerVideoFormat.hls,
     );
     _betterPlayerController = BetterPlayerController(betterPlayerConfiguration);
     _betterPlayerController.setupDataSource(dataSource);


### PR DESCRIPTION
Had this issue when trying to play HLS videos in example app

```
E/ExoPlayerImplInternal(10498): Playback error
E/ExoPlayerImplInternal(10498):   androidx.media3.exoplayer.ExoPlaybackException: Source error
E/ExoPlayerImplInternal(10498):       at androidx.media3.exoplayer.ExoPlayerImplInternal.handleIoException(ExoPlayerImplInternal.java:717)
E/ExoPlayerImplInternal(10498):       at androidx.media3.exoplayer.ExoPlayerImplInternal.handleMessage(ExoPlayerImplInternal.java:687)
E/ExoPlayerImplInternal(10498):       at android.os.Handler.dispatchMessage(Handler.java:102)
E/ExoPlayerImplInternal(10498):       at android.os.Looper.loopOnce(Looper.java:230)
E/ExoPlayerImplInternal(10498):       at android.os.Looper.loop(Looper.java:319)
E/ExoPlayerImplInternal(10498):       at android.os.HandlerThread.run(HandlerThread.java:67)
E/ExoPlayerImplInternal(10498):   Caused by: androidx.media3.exoplayer.source.UnrecognizedInputFormatException: None of the available extractors (FlvExtractor, FlacExtractor, WavExtractor, FragmentedMp4Extractor, Mp4Extractor, AmrExtractor, PsExtractor, OggExtractor, TsExtractor, MatroskaExtractor, AdtsExtractor, Ac3Extractor, Ac4Extractor, Mp3Extractor, AviExtractor, JpegExtractor, PngExtractor, WebpExtractor, BmpExtractor, HeifExtractor) could read the stream.{contentIsMalformed=false, dataType=1}
E/ExoPlayerImplInternal(10498):       at androidx.media3.exoplayer.source.BundledExtractorsAdapter.init(BundledExtractorsAdapter.java:94)
E/ExoPlayerImplInternal(10498):       at androidx.media3.exoplayer.source.ProgressiveMediaPeriod$ExtractingLoadable.load(ProgressiveMediaPeriod.java:1044)
E/ExoPlayerImplInternal(10498):       at androidx.media3.exoplayer.upstream.Loader$LoadTask.run(Loader.java:421)
E/ExoPlayerImplInternal(10498):       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
E/ExoPlayerImplInternal(10498):       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
E/ExoPlayerImplInternal(10498):       at java.lang.Thread.run(Thread.java:1012)
E/flutter (10498): [ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: PlatformException(VideoError, Video player had error androidx.media3.exoplayer.ExoPlaybackException: Source error, , null)
```
