### PR TITLE
fix: handle HLS subtitles that start with header WEBVTT

### DIFF
--- a/lib/src/subtitles/better_player_subtitle.dart
+++ b/lib/src/subtitles/better_player_subtitle.dart
@@ -22,6 +22,9 @@ class BetterPlayerSubtitle {
       }
 
       final scanner = value.split('\n');
+      if (scanner.isNotEmpty && scanner[0] == 'WEBVTT') {
+        return BetterPlayerSubtitle._();
+      }
       if (scanner.length == 2) {
         return _handle2LinesSubtitles(scanner);
       }


### PR DESCRIPTION
This fixes issue that sometimes occurs with HLS subtitles starting with `[WEBVTT, X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000]`

(cherry picked from commit f56f98f8af27024a0a7086531bd6328f7d9063ec)