### PR TITLE
fix(android): use track index instead of group index for audio selection

### DIFF
--- a/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
+++ b/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
@@ -696,18 +696,18 @@ internal class BetterPlayer(
                         for (groupElementIndex in 0 until group.length) {
                             val label = group.getFormat(groupElementIndex).label
                             if (name == label && index == groupIndex) {
-                                setAudioTrack(rendererIndex, groupIndex)
+                                setAudioTrack(rendererIndex, groupIndex, groupElementIndex)
                                 return
                             }
 
                             ///Fallback option
                             if (!hasStrangeAudioTrack && hasElementWithoutLabel && index == groupIndex) {
-                                setAudioTrack(rendererIndex, groupIndex)
+                                setAudioTrack(rendererIndex, groupIndex, groupElementIndex)
                                 return
                             }
                             ///Fallback option
                             if (hasStrangeAudioTrack && name == label) {
-                                setAudioTrack(rendererIndex, groupIndex)
+                                setAudioTrack(rendererIndex, groupIndex, groupElementIndex)
                                 return
                             }
                         }
@@ -715,24 +715,30 @@ internal class BetterPlayer(
                 }
             }
         } catch (exception: Exception) {
-            Log.e(TAG, "setAudioTrack failed$exception")
+            Log.e(TAG, "setAudioTrack failed " + exception)
         }
     }
 
-    private fun setAudioTrack(rendererIndex: Int, groupIndex: Int) {
+    private fun setAudioTrack(rendererIndex: Int, groupIndex: Int, trackIndex: Int) {
         val mappedTrackInfo = trackSelector.currentMappedTrackInfo
         if (mappedTrackInfo != null) {
-            val builder = trackSelector.parameters.buildUpon()
+            val groups = mappedTrackInfo.getTrackGroups(rendererIndex)
+            if (groupIndex < 0 || groupIndex >= groups.length) return
+            val group = groups.get(groupIndex)
+            if (trackIndex < 0 || trackIndex >= group.length) return
+
+            val builder = trackSelector.parameters
+                .buildUpon()
                 .setRendererDisabled(rendererIndex, false)
-                .addOverride(
+                .clearOverridesOfType(C.TRACK_TYPE_AUDIO)
+                .setOverrideForType(
                     TrackSelectionOverride(
-                        mappedTrackInfo.getTrackGroups(rendererIndex).get(groupIndex),
-                        mappedTrackInfo.getTrackGroups(rendererIndex)
-                            .indexOf(mappedTrackInfo.getTrackGroups(rendererIndex).get(groupIndex))
+                        group,
+                        listOf(trackIndex)
                     )
                 )
 
-            trackSelector.setParameters(builder)
+            trackSelector.setParameters(builder.build())
         }
     }
 


### PR DESCRIPTION
**🐛 What’s the issue**

On Android, switching audio tracks could throw an IndexOutOfBoundsException when calling setAudioTrack().
This happened because the code passed the group index from TrackGroupArray to the TrackSelectionOverride constructor, instead of the track index within the group.

For example:
groupCount = 2
groupLength = 1
selected groupIndex = 1  → valid
passed trackIndex = 1    → invalid (should be 0)


Since each group had only one element (group.length == 1), passing 1 caused the crash.

**💡 What’s changed**

Updated method signature to setAudioTrack(rendererIndex, groupIndex, trackIndex)

Pass the correct groupElementIndex (track index inside group) when selecting audio tracks

Added range checks for groupIndex and trackIndex

Replaced addOverride() with setOverrideForType() and clearOverridesOfType(C.TRACK_TYPE_AUDIO) to ensure proper override handling

This prevents IndexOutOfBoundsException and ensures stable audio track selection

**✅ Result**

Audio track selection now works correctly on Android for all HLS streams

No crashes when switching between audio languages (e.g. polski → English)

Behavior on iOS and Flutter API remains unchanged

**🧪 How to reproduce before fix**

Play an HLS stream with two audio tracks (e.g., Polish and English)

Call setAudioTrack("English", 1)

Observe crash:

java.lang.IndexOutOfBoundsException
at androidx.media3.common.TrackSelectionOverride.<init>(TrackSelectionOverride.java:77)

**🧰 How to test after fix**

Play the same stream

Switch audio track → no crash

Verify correct language is selected